### PR TITLE
[MOOSE-408] Dedupe class tokens in getBaseClassName to avoid duplicated classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entry gets prefixed with the category of the
 item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
+## [2026.07]
+- Fixed: `create-wp-controls.js` was duplicating classes in `getBaseClassName` when `propsClassName` already included `attributeClassName`/`attributeClasses`. Tokens are now deduped across all three sources. [MOOSE-408](https://moderntribe.atlassian.net/browse/MOOSE-408)
+
 ## [2026.06]
 - Chore: WordPress Core update to v7.0, plugins, Composer & NPM deps updates. update ESLint config file format.
 

--- a/wp-content/themes/core/assets/js/utils/create-wp-controls.js
+++ b/wp-content/themes/core/assets/js/utils/create-wp-controls.js
@@ -201,14 +201,21 @@ const getBaseClassName = ( {
 	attributeClassName,
 	attributeClasses,
 } = {} ) => {
-	return [
+	// The three sources may overlap (e.g. WP core's customClassName support
+	// merges attributeClassName into propsClassName earlier in the
+	// pipeline), so dedupe tokens across all three instead of concatenating
+	// them.
+	const tokens = [
 		normalizeClassSource( propsClassName ),
 		normalizeClassSource( attributeClassName ),
 		normalizeClassSource( attributeClasses ),
 	]
 		.filter( Boolean )
 		.join( ' ' )
-		.trim();
+		.split( /\s+/ )
+		.filter( Boolean );
+
+	return [ ...new Set( tokens ) ].join( ' ' ).trim();
 };
 
 /**


### PR DESCRIPTION
## What does this do/fix?

This pull request fixes an issue in the `create-wp-controls.js` utility where CSS classes were being duplicated in the output of `getBaseClassName` when `propsClassName` already included `attributeClassName` or `attributeClasses`. The logic now deduplicates class tokens across all three sources to prevent redundant classes.

Bug fix:

* Updated `getBaseClassName` in `create-wp-controls.js` to deduplicate class name tokens across `propsClassName`, `attributeClassName`, and `attributeClasses`, ensuring no duplicate classes are output.
* Documented the fix in the `CHANGELOG.md` under version 2026.07, referencing [MOOSE-408](https://moderntribe.atlassian.net/browse/MOOSE-408).

Note: on the live front-end this is largely masked because WordPress's server-side layout support re-serializes the class attribute via WP_HTML_Tag_Processor (which treats classes as a set), but the duplication is still present in stored post_content.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-408)

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.

[MOOSE-408]: https://moderntribe.atlassian.net/browse/MOOSE-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ