### PR TITLE
Localize announcement dismiss button aria-label

### DIFF
--- a/wp-content/themes/core/blocks/tribe/announcements/render.php
+++ b/wp-content/themes/core/blocks/tribe/announcements/render.php
@@ -38,7 +38,7 @@ $c = Announcement_Block_Controller::factory( [
 
 	<?php if ( $c->is_dismissible() ) : ?>
 		<div class="b-announcement__dismiss-wrapper">
-			<button type="button" class="b-announcement__dismiss" aria-label="Dismiss announcement">
+			<button type="button" class="b-announcement__dismiss" aria-label="<?php echo esc_attr__( 'Dismiss announcement', 'tribe' ); ?>">
 				<span class="b-announcement__dismiss-text"><?php echo esc_html__( 'Dismiss', 'tribe' ); ?></span>
 			</button>
 		</div>


### PR DESCRIPTION
## What does this do/fix?

This pull request makes a small accessibility and localization improvement to the announcement block. The change ensures that the `aria-label` for the dismiss button is properly localized using WordPress translation functions.

* Updated the `aria-label` attribute on the dismiss button in `render.php` to use `esc_attr__()` for localization and escaping, improving accessibility and internationalization.