### PR TITLE
[MOOSE-384] FE: Accordion Block Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Each changelog entr
 item (Added, Changed, Depreciated, Removed, Fixed, Security).
 
 @@ [2026.08]
-- CHore WordPress Core update to 7.0.3, plugin, composer & npm package updates.
+- Chore: WordPress Core update to 7.0.3, plugin, composer & npm package updates.
+- Added: Accordion block now has a toggle for enabling schema.org schema markup on the specific Accordion block.
 
 ## [2026.06]
 - Chore: WordPress Core update to v7.0, plugins, Composer & NPM deps updates. update ESLint config file format.

--- a/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
+++ b/wp-content/plugins/core/src/Blocks/Blocks_Definer.php
@@ -3,6 +3,7 @@
 namespace Tribe\Plugin\Blocks;
 
 use DI;
+use Tribe\Plugin\Blocks\Filters\Accordion_Filter;
 use Tribe\Plugin\Blocks\Filters\Contracts\Filter_Factory;
 use Tribe\Plugin\Blocks\Filters\Paragraph_Filter;
 use Tribe\Plugin\Core\Interfaces\Definer_Interface;
@@ -102,6 +103,7 @@ class Blocks_Definer implements Definer_Interface {
 			] ),
 
 			self::FILTERS         => DI\add( [
+				DI\get( Accordion_Filter::class ),
 				DI\get( Paragraph_Filter::class ),
 			] ),
 

--- a/wp-content/plugins/core/src/Blocks/Filters/Accordion_Filter.php
+++ b/wp-content/plugins/core/src/Blocks/Filters/Accordion_Filter.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace Tribe\Plugin\Blocks\Filters;
+
+use Tribe\Plugin\Blocks\Filters\Contracts\Block_Content_Filter;
+use WP_HTML_Processor;
+
+/**
+ * Appends FAQPage structured data to accordions that opt in via the
+ * "Enable FAQ Schema" toggle (see blocks/core/accordion/editor.js).
+ */
+class Accordion_Filter extends Block_Content_Filter {
+
+	public const string BLOCK = 'core/accordion';
+
+	private const QUESTION_CLASS = 'wp-block-accordion-heading__toggle-title';
+
+	private const ANSWER_CLASS = 'wp-block-accordion-panel';
+
+	/**
+	 * @param array<string, mixed> $parsed_block
+	 */
+	public function filter_block_content( string $block_content, array $parsed_block, object $block ): string {
+		if ( ! $block_content || ! wp_validate_boolean( $parsed_block['attrs']['enableFaqSchema'] ?? false ) ) {
+			return $block_content;
+		}
+
+		$entities = $this->extract_entities( $block_content );
+
+		if ( ! $entities ) {
+			return $block_content;
+		}
+
+		// JSON_HEX_TAG so answer text containing `</script>` cannot break out of the tag.
+		$json = wp_json_encode( [
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'mainEntity' => $entities,
+		], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG );
+
+		if ( false === $json ) {
+			return $block_content;
+		}
+
+		return $block_content . wp_get_inline_script_tag( $json, [ 'type' => 'application/ld+json' ] );
+	}
+
+	/**
+	 * Walks the rendered accordion once, pairing each heading title with the panel that follows it.
+	 *
+	 * A nested accordion's headings/panels are consumed as part of the outer answer text, and the
+	 * nested block emits its own schema if it also opted in.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function extract_entities( string $block_content ): array {
+		$processor = WP_HTML_Processor::create_fragment( $block_content );
+
+		if ( ! $processor ) {
+			return [];
+		}
+
+		$entities = [];
+		$question = '';
+
+		while ( $processor->next_tag() ) {
+			if ( $processor->has_class( self::QUESTION_CLASS ) ) {
+				$question = $this->inner_text( $processor );
+
+				continue;
+			}
+
+			if ( ! $question || ! $processor->has_class( self::ANSWER_CLASS ) ) {
+				continue;
+			}
+
+			$answer = $this->inner_text( $processor );
+
+			if ( $answer ) {
+				$entities[] = [
+					'@type'          => 'Question',
+					'name'           => $question,
+					'acceptedAnswer' => [
+						'@type' => 'Answer',
+						'text'  => $answer,
+					],
+				];
+			}
+
+			$question = '';
+		}
+
+		return $entities;
+	}
+
+	/**
+	 * Collapsed text content of the element the processor is currently on, consuming it.
+	 *
+	 * ponytail: text only — schema.org accepts HTML in acceptedAnswer.text, but the HTML API
+	 * has no inner-HTML accessor, so links/lists in answers flatten to their text. Swap in
+	 * DOMDocument + wp_kses if a rich result ever needs the markup.
+	 */
+	private function inner_text( WP_HTML_Processor $processor ): string {
+		$depth = $processor->get_current_depth();
+		$text  = '';
+
+		// A child's closer returns to $depth; only this element's closer drops below it.
+		while ( $processor->next_token() && $processor->get_current_depth() >= $depth ) {
+			if ( '#text' !== $processor->get_token_type() ) {
+				continue;
+			}
+
+			$text .= ' ' . $processor->get_modifiable_text();
+		}
+
+		// Cast covers preg_replace returning null on invalid UTF-8: the pair is dropped, not mangled.
+		return trim( (string) preg_replace( '/\s+/u', ' ', $text ) );
+	}
+
+}

--- a/wp-content/themes/core/blocks/core/accordion/editor.js
+++ b/wp-content/themes/core/blocks/core/accordion/editor.js
@@ -1,0 +1,27 @@
+import { __ } from '@wordpress/i18n';
+import createWPControls from 'utils/create-wp-controls';
+
+const settings = {
+	attributes: {
+		enableFaqSchema: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	blocks: [ 'core/accordion' ],
+	controls: [
+		{
+			attribute: 'enableFaqSchema',
+			defaultValue: false,
+			helpText: __(
+				"Generate FAQPage structured data from this accordion's questions and answers.",
+				'tribe'
+			),
+			label: __( 'Enable FAQ Schema', 'tribe' ),
+			panel: __( 'Structured Data', 'tribe' ),
+			type: 'toggle',
+		},
+	],
+};
+
+createWPControls( settings );


### PR DESCRIPTION
## What does this do/fix?

This pull request introduces support for generating FAQPage structured data (schema.org) for the `core/accordion` block when a new "Enable FAQ Schema" toggle is enabled. The main changes add both the backend filter to generate the JSON-LD schema and the editor control for users to opt in.

**FAQ Schema Support for Accordion Block:**

* Added a new `Accordion_Filter` class that appends FAQPage structured data to the `core/accordion` block if the "Enable FAQ Schema" toggle is enabled. The filter parses the block's HTML to extract question and answer pairs and outputs the appropriate JSON-LD.
* Registered the new `Accordion_Filter` in the block filters definition so it is applied when rendering blocks. [[1]](diffhunk://#diff-1fe6224df01a14262c01a9d72ec7c0d791ac5bf7d77f0fe8464a7986028112ebR6) [[2]](diffhunk://#diff-1fe6224df01a14262c01a9d72ec7c0d791ac5bf7d77f0fe8464a7986028112ebR106)

**Block Editor Enhancements:**

* Added a new toggle control in the `core/accordion` block editor (`editor.js`) allowing users to enable or disable FAQ schema generation for each accordion instance.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/MOOSE-384)

Screenshots/video:
- Editor view: https://p.tri.be/i/hlmgbC
- FE view: https://p.tri.be/i/bY8GYI

## Pull request checklist
- [x] I've added a changelog entry for these changes.
- [x] I've linked to a relevant Jira issue.
- [x] I've captured a screenshot or screencast of the changes and linked it above.
